### PR TITLE
Fix plotly image export by adding kaleido

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ filtered_df = df[(df[column] >= lower) & (df[column] <= upper)]
 ```bash
 pip install -r requirements.txt
 ```
+The `kaleido` package is required for exporting Plotly figures to images. It is
+included in the `requirements.txt`, but you can install it manually with:
+
+```bash
+pip install kaleido
+```
 
 2. Launch the app:
 

--- a/app.py
+++ b/app.py
@@ -270,6 +270,12 @@ def plotly_to_image(fig, format="png", **kwargs):
     try:
         img_bytes = fig.to_image(format=format, **kwargs)
         return BytesIO(img_bytes)
+    except (ValueError, ImportError) as e:
+        st.warning(
+            "Unable to export figure to image. Ensure the 'kaleido' package is installed. "
+            f"Error: {e}"
+        )
+        return None
     except Exception as e:
         st.warning(f"Unable to export figure to image: {e}")
         return None

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ openpyxl==3.1.5
 plotly==5.23.0
 reportlab==4.2.2
 streamlit==1.38.0
+kaleido==0.2.1


### PR DESCRIPTION
## Summary
- include `kaleido` in dependencies so plotly charts can be exported
- document kaleido requirement in README
- warn about missing kaleido in `plotly_to_image`

## Testing
- `python -m py_compile app.py`
- `pip install -r requirements.txt -q`
- `python - <<'PY'
import kaleido
print('kaleido version', kaleido.__version__)
PY`

------
https://chatgpt.com/codex/tasks/task_e_6876f52b16e08329a7a3a08c02a10b66