### PR TITLE
Improve Kaleido handling and requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,9 @@ filtered_df = df[(df[column] >= lower) & (df[column] <= upper)]
 ```bash
 pip install -r requirements.txt
 ```
-The `kaleido` package is required for exporting Plotly figures to images. It is
-included in the `requirements.txt`, but you can install it manually with:
+The application requires the `kaleido` package for exporting Plotly figures.
+It is included in `requirements.txt`, but if you encounter errors related to
+image export, ensure Kaleido is installed manually with:
 
 ```bash
 pip install kaleido

--- a/app.py
+++ b/app.py
@@ -22,6 +22,16 @@ from reportlab.platypus import (
 from reportlab.lib.styles import getSampleStyleSheet
 from reportlab.lib import colors
 
+# Verify that the Kaleido package is available for Plotly image export
+try:
+    import kaleido  # noqa: F401
+except ImportError:  # pragma: no cover - handled at runtime
+    st.error(
+        "Kaleido is required for exporting charts as images."
+        "\nInstall it with `pip install kaleido` and restart the app."
+    )
+    st.stop()
+
 # Configure Streamlit page
 st.set_page_config(
     page_title="TTU Purchase Orders Log",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-pandas==2.2.2
-openpyxl==3.1.5
-plotly==5.23.0
-reportlab==4.2.2
-streamlit==1.38.0
-kaleido==0.2.1
+pandas>=2.2.2
+openpyxl>=3.1.5
+plotly>=5.23.0
+reportlab>=4.2.2
+streamlit>=1.38.0
+kaleido>=0.2.1


### PR DESCRIPTION
## Summary
- verify Kaleido is installed when the app starts
- loosen dependency versions to avoid installation conflicts
- clarify Kaleido instructions in README

## Testing
- `pip check`
- `python -m py_compile app.py`
- `streamlit run app.py` *(server started and stopped)*

------
https://chatgpt.com/codex/tasks/task_e_6876fce9bdc48329ab2ef2e37815ee0f