### PR TITLE
Improve kaleido error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,16 @@ TTU Purchase Orders Log is a web application built with [Streamlit](https://stre
   - `openpyxl`
   - `plotly`
   - `streamlit`
-  - `kaleido` for exporting figures
+- `kaleido` for exporting figures
+
+When using Kaleido, Google Chrome must be installed. If Chrome is not already
+available on your system you can install it automatically by running:
+
+```bash
+plotly_get_chrome -y
+```
+
+This command downloads a local copy of Chrome for use by Kaleido.
 
 Install the dependencies with:
 

--- a/app.py
+++ b/app.py
@@ -307,7 +307,14 @@ def plotly_to_image(fig, format="png", **kwargs):
         )
         return None
     except Exception as e:
-        st.warning(f"Unable to export figure to image: {e}")
+        error_msg = str(e)
+        if "Google Chrome" in error_msg:
+            st.warning(
+                "Unable to export figure to image. Kaleido requires Google Chrome.\n"
+                "Run `plotly_get_chrome -y` to install a local copy or install Chrome manually."
+            )
+        else:
+            st.warning(f"Unable to export figure to image: {error_msg}")
         return None
 
 


### PR DESCRIPTION
## Summary
- document Chrome requirement for kaleido
- warn users to run `plotly_get_chrome` when Chrome is missing

## Testing
- `python -m py_compile app.py`
- `streamlit run app.py` (manual run)

------
https://chatgpt.com/codex/tasks/task_e_6877b31186bc83298a545950ba7db050