### PR TITLE
Add Edge support for Plotly exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,14 +20,16 @@ TTU Purchase Orders Log is a web application built with [Streamlit](https://stre
   - `streamlit`
 - `kaleido` for exporting figures
 
-When using Kaleido, Google Chrome must be installed. If Chrome is not already
-available on your system you can install it automatically by running:
+When using Kaleido, a Chromium-based browser such as Microsoft Edge or Google
+Chrome must be installed. Set the `KALIEDO_BROWSER_PATH` environment variable
+to the path of your preferred browser if it is not Chrome. If no browser is
+available you can install a bundled copy of Chromium by running:
 
 ```bash
 plotly_get_chrome -y
 ```
 
-This command downloads a local copy of Chrome for use by Kaleido.
+This command downloads a local copy of Chromium for use by Kaleido.
 
 Install the dependencies with:
 

--- a/app.py
+++ b/app.py
@@ -4,6 +4,7 @@
 # Standard library imports
 import time
 from io import BytesIO
+import os
 
 # Third-party imports
 import streamlit as st
@@ -31,6 +32,20 @@ except ImportError:  # pragma: no cover - handled at runtime
         "\nInstall it with `pip install kaleido` and restart the app."
     )
     st.stop()
+
+# Attempt to automatically use Microsoft Edge as the browser for Kaleido if
+# the user has not specified one.
+if "KALIEDO_BROWSER_PATH" not in os.environ:
+    edge_paths = [
+        r"C:\\Program Files (x86)\\Microsoft\\Edge\\Application\\msedge.exe",
+        r"C:\\Program Files\\Microsoft\\Edge\\Application\\msedge.exe",
+        "/usr/bin/microsoft-edge",
+        "/usr/bin/microsoft-edge-stable",
+    ]
+    for _path in edge_paths:
+        if os.path.exists(_path):
+            os.environ["KALIEDO_BROWSER_PATH"] = _path
+            break
 
 # Configure Streamlit page
 st.set_page_config(
@@ -308,10 +323,10 @@ def plotly_to_image(fig, format="png", **kwargs):
         return None
     except Exception as e:
         error_msg = str(e)
-        if "Google Chrome" in error_msg:
+        if "Google Chrome" in error_msg or "no suitable chromium" in error_msg.lower():
             st.warning(
-                "Unable to export figure to image. Kaleido requires Google Chrome.\n"
-                "Run `plotly_get_chrome -y` to install a local copy or install Chrome manually."
+                "Unable to export figure to image. Kaleido requires a Chromium-based browser such as Microsoft Edge or Google Chrome.\n"
+                "Set the KALIEDO_BROWSER_PATH environment variable to the browser executable or run `plotly_get_chrome -y` to install a local copy."
             )
         else:
             st.warning(f"Unable to export figure to image: {error_msg}")


### PR DESCRIPTION
## Summary
- allow Kaleido to use Microsoft Edge by default
- clarify README that any Chromium browser (Edge or Chrome) works
- improve warning message when no suitable browser is found

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6878408e0468832980eb5b4638183812