### PR TITLE
Add visualizations and remove Kaleido dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,18 +18,6 @@ TTU Purchase Orders Log is a web application built with [Streamlit](https://stre
   - `openpyxl`
   - `plotly`
   - `streamlit`
-- `kaleido` for exporting figures
-
-When using Kaleido, a Chromium-based browser such as Microsoft Edge or Google
-Chrome must be installed. Set the `KALIEDO_BROWSER_PATH` environment variable
-to the path of your preferred browser if it is not Chrome. If no browser is
-available you can install a bundled copy of Chromium by running:
-
-```bash
-plotly_get_chrome -y
-```
-
-This command downloads a local copy of Chromium for use by Kaleido.
 
 Install the dependencies with:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,3 @@ openpyxl>=3.1.5
 plotly>=5.23.0
 reportlab>=4.2.2
 streamlit>=1.38.0
-kaleido>=0.2.1


### PR DESCRIPTION
## Summary
- drop Kaleido integration and disable image export
- update docs and requirements accordingly
- add plots for every data table
- generate charts for late orders, PO counts, recent orders, and vendor totals

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_687849707bc083299c5a05ce3b0639b1