### PR TITLE
Add descriptive statistics feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ TTU Purchase Orders Log is a web application built with [Streamlit](https://stre
 - Removes outliers from charts using the Interquartile Range (IQR) method
 - Interactive graphs powered by Plotly
 - Option to export analysis results to a PDF report
+- Provides descriptive statistics and distribution charts for numeric data
 
 ## Requirements
 


### PR DESCRIPTION
## Summary
- compute descriptive statistics for numeric columns
- show order total distribution chart
- mention new analytics capability in README

## Testing
- `python -m py_compile app.py`
- `flake8 app.py` *(fails: command not found before install)*


------
https://chatgpt.com/codex/tasks/task_e_688186e85dec83299d95caec1982c0cf