### PR TITLE
Fix Streamlit image argument

### DIFF
--- a/app.py
+++ b/app.py
@@ -444,7 +444,7 @@ def main():
         # Clean logo display at the top
         if os.path.exists("TTU_LOGO.jpg"):
             # Display logo at full sidebar width
-            st.image("TTU_LOGO.jpg", use_container_width=True)
+            st.image("TTU_LOGO.jpg", use_column_width=True)
             st.markdown("<br>", unsafe_allow_html=True)
         
         # Data Upload Section


### PR DESCRIPTION
## Summary
- ensure sidebar logo uses `use_column_width` for Streamlit <1.30 compatibility

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6883a4d700f48329914b1d8852666682